### PR TITLE
Set an alternate environment variable for backend listening port

### DIFF
--- a/server.js
+++ b/server.js
@@ -6,7 +6,7 @@ const app = express();
 const bodyParser = require("body-parser");
 const cookieParser = require("cookie-parser")
 const router = require("./routes");
-const port = process.env.PORT || 8000; //azure gives port as an environment variable
+const port = process.env.ALT_PORT || process.env.PORT || 8000; //azure gives port as an environment variable
 
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(bodyParser.json());


### PR DESCRIPTION
Backend and frontend both listened to PORT environment variable if
set, which means they would clash.  Set the backend port separately
with ALT_PORT variable if need be.