### PR TITLE
fix schedule supervisor to accept javascript null

### DIFF
--- a/models/schedule.js
+++ b/models/schedule.js
@@ -52,7 +52,11 @@ async function updateSchedule(current, updates) {
     err.name = 'Unknown schedule'
     throw err
   }
-
+  
+  if(updates.supervisor_id === 'null'){
+    updates.supervisor_id = null;
+  }
+  
   return knex('scheduled_range_supervision')
     .whereIn('id', ids)
     .update(updates)


### PR DESCRIPTION
Atm set supervisor can't be removed. Sending null gets removed somewhere along the way. And javascript fetch instead of null encapsulates it as 'null' which Postgre doesn't allow for a number input.

This just checks 'null' and replaces with null.