### PR TITLE
fix only supervisors in scheduling

### DIFF
--- a/front/src/Scheduling.js
+++ b/front/src/Scheduling.js
@@ -30,7 +30,7 @@ moment.locale("fi");
 
 async function getRangeSupervisors(token){
   try{
-    let response = await fetch("/api/user", {
+    let response = await fetch("/api/user?role=supervisor", {
       method: 'GET',
       headers: {
         'Accept': 'application/json',


### PR DESCRIPTION
Fixes an error that I overlooked in development where not all of the users are actually supervisors.