### PR TITLE
Non superusers allowed to query their own info

### DIFF
--- a/middlewares/user.js
+++ b/middlewares/user.js
@@ -12,6 +12,8 @@ const canRead = function canReadUserData(request, response, next) {
     return next()
   }
 
+  // Make sure the user being queried has the same id and/or name as the active
+  // session
   if(_.isMatch(_.pick(session, 'name', 'id'), _.pick(query, 'name', 'id'))) {
     return next()
   }

--- a/routes.js
+++ b/routes.js
@@ -28,7 +28,7 @@ router.route('/user')
     middlewares.user.readFilter
     , controllers.user.readFilter)
   .post(
-    middlewares.user.hasProperty('role', 'supervisor')
+    middlewares.user.hasProperty('role', 'superuser')
     , middlewares.user.create
     , controllers.user.create)
 


### PR DESCRIPTION
Change GET /api/user endpoint slightly to allow users' to query information
about themselves. This doesn't allow regular users to edit their information,
or delete their account. Also, regular users may only query using the query
strings id and name, both being uniquely identifying properties.