### PR TITLE
Scheduling fixes

### DIFF
--- a/front/src/Scheduling.js
+++ b/front/src/Scheduling.js
@@ -64,7 +64,6 @@ class Scheduling extends Component {
         rangeSupervisorSwitch: false,
         rangeSupervisorId: '',
         rangeSupervisionScheduled: false,
-        rangeSupervisionChanged:false,
         daily:false,
         weekly:false,
         monthly:false,
@@ -463,16 +462,8 @@ class Scheduling extends Component {
         }
       }
       if(rangeStatus !== null){
-        //check if supervisor is different otherwise keep old rangeSupervision
-        if(this.state.rangeSupervisionChanged && isRepeat === false){
-          const rangeSupervisionRes = await rangeSupervision(rsId,srsId,rangeStatus,rangeSupervisionScheduled,this.state.token);
-          console.log("rangeSupervisionRes",rangeSupervisionRes,rangeSupervisionScheduled);
-        }
-        //on repeats don't care and override
-        else if(isRepeat){
-          const rangeSupervisionRes = await rangeSupervision(rsId,srsId,rangeStatus,rangeSupervisionScheduled,this.state.token);
-          console.log("rangeSupervisionRes",rangeSupervisionRes,rangeSupervisionScheduled);
-        }
+        const rangeSupervisionRes = await rangeSupervision(rsId,srsId,rangeStatus,rangeSupervisionScheduled,this.state.token);
+        console.log("rangeSupervisionRes",rangeSupervisionRes,rangeSupervisionScheduled);
       }
       else console.log("range status null")
       
@@ -651,11 +642,6 @@ class Scheduling extends Component {
     
     const handleValueChange = (event) => {
       console.log("Value change",event.target.name, event.target.value)
-      if(event.target.name === 'rangeSupervisorId'){
-        this.setState({
-           rangeSupervisionChanged:true
-        });
-      }
       this.setState({
          [event.target.name]: event.target.value
       });


### PR DESCRIPTION
Unify current and repeat calls to use the same getSchedulingDate.
Fixes repeat info to check existing from database instead of state.
Fixes repeat supervisions getting the correct id from posts.
Removed supervision changed check now simply overrides supervision to closed/absent/not confirmed