### PR TITLE
Use TLS/SSL

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -2,7 +2,7 @@ const crypto = require('crypto')
 
 const config = {
   server: {
-    host: process.env.SERVER_HOST || 'http://localhost:3000',
+    host: process.env.SERVER_HOST || 'https://localhost:3000',
     port: 8000
   },
   jwt: {

--- a/front/package.json
+++ b/front/package.json
@@ -21,12 +21,12 @@
     "react-scripts": "3.3.0"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "HTTPS=true react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
-  "proxy": "http://localhost:8000/",
+  "proxy": "https://localhost:8000/",
   "eslintConfig": {
     "extends": "react-app"
   },

--- a/server.js
+++ b/server.js
@@ -9,6 +9,8 @@ const helmet = require('helmet');
 const router = require("./routes");
 const port = process.env.ALT_PORT || process.env.PORT || 8000; //azure gives port as an environment variable
 const os = require("os")
+const fs = require('fs')
+const https = require('https')
 
 app.use(helmet());
 app.use(bodyParser.urlencoded({ extended: true }));
@@ -21,9 +23,13 @@ app.use("/api", router);
 // Rendering the front-end react app
 app.use("/", express.static("front/build/"))
 
-app.listen(port, () => {
-    console.log("Server on " + port)
-})
+// Wrap the express app inside a https server
+const server = https.createServer({
+  key: fs.readFileSync('key.pem'),
+  cert: fs.readFileSync('certificate.pem')
+}, app)
+
+server.listen(port, () => console.log(`Server on ${port}`))
 
 if(process.env.NODE_ENV === 'stable' && os.hostname() === 'tasera.netum.fi') {
   if(process.getgid() === 0 || process.getuid() === 0) {


### PR DESCRIPTION
Enables connections using HTTPS, instead of the old, insecure HTTP. For now
when developing, the environment variable NODE_TLS_REJECT_UNAUTHORIZED=0 needs
to be set before the server is started. Also required are a
certificate (certificate.pem), and a key (key.pem), both inside the root of the
project, I recommend generating these using openssl.