### PR TITLE
Translate additions

### DIFF
--- a/front/src/Scheduling.js
+++ b/front/src/Scheduling.js
@@ -29,9 +29,14 @@ import * as data from './texts/texts.json';
 import moment from 'moment';
 import "moment/locale/fi";
 
-const lang = localStorage.getItem("language") === '0' ? 'fi' : 'en'
+let lang = "fi"; //fallback
+if(localStorage.getItem("language") === '0') {
+  lang = 'fi';
+}
+else if(localStorage.getItem("language") === '1'){
+  lang = 'en';
+}
 moment.locale(lang);
-console.log("lang",lang,moment.localeData());
 
 async function getRangeSupervisors(token){
   try{
@@ -73,7 +78,8 @@ class Scheduling extends Component {
         weekly:false,
         monthly:false,
         repeatCount:1,
-        token:'SECRET-TOKEN'
+        token:'SECRET-TOKEN',
+        datePickerKey:1
       };
   }
   

--- a/front/src/utils/Utils.js
+++ b/front/src/utils/Utils.js
@@ -45,15 +45,29 @@ export async function getSchedulingWeek(date) {
 }
 
 export function dayToString(i) {
-  const lang = localStorage.getItem("language") === '0' ? 'fi' : 'en';
+  let lang = "fi"; //fallback
+  if(localStorage.getItem("language") === '0') {
+    lang = 'fi';
+  }
+  else if(localStorage.getItem("language") === '1'){
+    lang = 'en';
+  }
   moment.locale(lang);
   //en/fi have different numbers for start date
   if(lang === 'fi') i--;
-  return moment().weekday(i).format('dddd').toUpperCase();
+  const dayString = moment().weekday(i).format('dddd');
+  //first letter only to uppercase
+  return dayString.charAt(0).toUpperCase() + dayString.slice(1);
 }
 
 export function monthToString(i) {
-  const lang = localStorage.getItem("language") === '0' ? 'fi' : 'en';
+  let lang = "fi"; //fallback
+  if(localStorage.getItem("language") === '0') {
+    lang = 'fi';
+  }
+  else if(localStorage.getItem("language") === '1'){
+    lang = 'en';
+  }
   moment.locale(lang);
   return moment().month(i).format('MMMM');
 }


### PR DESCRIPTION
Scheduling datepicker texts other than the action buttons now have correct texts according to language. There doesn't seem to be a easy way to affect the buttons.
Dayview and Trackview also get weekday in correct language with changes to utils.